### PR TITLE
Updating bindings for ofLight and ofMaterial. Added ofFloatColor.

### DIFF
--- a/src/bindings/Gl.cpp
+++ b/src/bindings/Gl.cpp
@@ -266,39 +266,84 @@ luabind::scope registerGl() {
 			.def("setSpecularColor", &lightSetSpecularColor4)
 			.def("setSpecularColor", &lightSetSpecularHexColor)
 			
-			.def("getLightID", &ofLight::getLightID)
-			.def("customDraw", &ofLight::customDraw),
+            .def("setAmbientColor", (void(ofLight::*)(const ofFloatColor&)) &ofLight::setAmbientColor)
+            .def("setDiffuseColor", (void(ofLight::*)(const ofFloatColor&)) &ofLight::setDiffuseColor)
+            .def("setSpecularColor", (void(ofLight::*)(const ofFloatColor&)) &ofLight::setSpecularColor)
+            .def("getAmbientColor", (ofFloatColor(ofLight::*)(void)) &ofLight::getAmbientColor)
+            .def("getDiffuseColor", (ofFloatColor(ofLight::*)(void)) &ofLight::getDiffuseColor)
+            .def("getSpecularColor", (ofFloatColor(ofLight::*)(void)) &ofLight::getSpecularColor)
+            .def("getLightID", (int(ofLight::*)(void)) &ofLight::getLightID)
+            .def("draw", (void(ofNode::*)(void)) &ofLight::draw)
+            .def("customDraw", (void(ofLight::*)(void)) &ofLight::customDraw)
+            
+            // from ofNode, transform functionality
+            .def("getPosition", (ofVec3f(ofLight::*)(void)) &ofLight::getPosition)
+            .def("getX", (float(ofLight::*)(void)) &ofLight::getX)
+            .def("getY", (float(ofLight::*)(void)) &ofLight::getY)
+            .def("getZ", (float(ofLight::*)(void)) &ofLight::getZ)
+            .def("getXAxis", (ofVec3f(ofLight::*)(void)) &ofLight::getXAxis)
+            .def("getYAxis", (ofVec3f(ofLight::*)(void)) &ofLight::getYAxis)
+            .def("getZAxis", (ofVec3f(ofLight::*)(void)) &ofLight::getZAxis)
+            .def("getSideDir", (ofVec3f(ofLight::*)(void)) &ofLight::getSideDir)
+            .def("getLookAtDir", (ofVec3f(ofLight::*)(void)) &ofLight::getLookAtDir)
+            .def("getUpDir", (ofVec3f(ofLight::*)(void)) &ofLight::getUpDir)
+            .def("getPitch", (float(ofLight::*)(void)) &ofLight::getPitch)
+            .def("getHeading", (float(ofLight::*)(void)) &ofLight::getHeading)
+            .def("getRoll", (float(ofLight::*)(void)) &ofLight::getRoll)
+            .def("getOrientationQuat", (ofQuaternion(ofLight::*)(void)) &ofLight::getOrientationQuat)
+            .def("getOrientationEuler", (ofVec3f(ofLight::*)(void)) &ofLight::getOrientationEuler)
+            .def("getScale", (ofVec3f(ofLight::*)(void)) &ofLight::getScale)
+            .def("getLocalTransformMatrix", (ofMatrix4x4(ofLight::*)(void)) &ofLight::getLocalTransformMatrix)
+            .def("getGlobalTransformMatrix", (ofMatrix4x4(ofLight::*)(void)) &ofLight::getGlobalTransformMatrix)
+            .def("getGlobalPosition", (ofVec3f(ofLight::*)(void)) &ofLight::getGlobalPosition)
+            .def("getGlobalOrientation", (ofQuaternion(ofLight::*)(void)) &ofLight::getGlobalOrientation)
+            .def("setTransformMatrix", (void(ofLight::*)(const ofMatrix4x4&)) &ofLight::setTransformMatrix)
+            .def("setPosition", (void(ofLight::*)(float,float,float)) &ofLight::setPosition)
+            .def("setPosition", (void(ofLight::*)(const ofVec3f&)) &ofLight::setPosition)
+            .def("setGlobalPosition", (void(ofLight::*)(float,float,float)) &ofLight::setGlobalPosition)
+            .def("setGlobalPosition", (void(ofLight::*)(const ofVec3f&)) &ofLight::setGlobalPosition)
+            .def("setOrientation", (void(ofLight::*)(const ofQuaternion&)) &ofLight::setOrientation)
+            .def("setOrientation", (void(ofLight::*)(const ofVec3f&)) &ofLight::setOrientation)
+            .def("setGlobalOrientation", (void(ofLight::*)(const ofQuaternion&)) &ofLight::setGlobalOrientation)
+            .def("setScale", (void(ofLight::*)(float,float,float)) &ofLight::setScale)
+            .def("setScale", (void(ofLight::*)(const ofVec3f&)) &ofLight::setScale)
+            .def("move", (void(ofLight::*)(float,float,float)) &ofLight::move)
+            .def("move", (void(ofLight::*)(const ofVec3f&)) &ofLight::move)
+            .def("truck", (void(ofLight::*)(float)) &ofLight::truck)
+            .def("boom", (void(ofLight::*)(float)) &ofLight::boom)
+            .def("dolly", (void(ofLight::*)(float)) &ofLight::dolly)
+            .def("tilt", (void(ofLight::*)(float)) &ofLight::tilt)
+            .def("pan", (void(ofLight::*)(float)) &ofLight::pan)
+            .def("roll", (void(ofLight::*)(float)) &ofLight::roll)
+            .def("rotate", (void(ofLight::*)(const ofQuaternion&)) &ofLight::rotate)
+            .def("rotate", (void(ofLight::*)(float,const ofVec3f&)) &ofLight::rotate)
+            .def("rotate", (void(ofLight::*)(float,float,float,float)) &ofLight::rotate)
+            .def("rotateAround", (void(ofLight::*)(const ofQuaternion&,const ofVec3f&)) &ofLight::rotateAround)
+            .def("rotateAround", (void(ofLight::*)(float,const ofVec3f&,const ofVec3f&)) &ofLight::rotateAround)
+            .def("lookAt", (void(ofLight::*)(const ofVec3f&,ofVec3f)) &ofLight::lookAt)
+            .def("orbit", (void(ofLight::*)(float,float,float,const ofVec3f&)) &ofLight::orbit)
+            .def("orbit", (void(ofLight::*)(float,float,float,ofNode&)) &ofLight::orbit),
 			
 		///////////////////////////////
 		/// \section ofMaterial.h
 		
 		class_<ofMaterial>("Material")
 			.def(constructor<>())
-			
-			.def("setColors", &ofMaterial::setColors)
-			
-			.def("getDiffuseColor", &ofMaterial::getDiffuseColor)
-			.def("setDiffuseColor", &ofMaterial::setDiffuseColor)
-			.property("diffuseColor", &ofMaterial::getDiffuseColor, &ofMaterial::setDiffuseColor)
-			
-			.def("getAmbientColor", &ofMaterial::getAmbientColor)
-			.def("setAmbientColor", &ofMaterial::setAmbientColor)
-			.property("ambientColor", &ofMaterial::getAmbientColor, &ofMaterial::setAmbientColor)
-			
-			.def("getSpecularColor", &ofMaterial::getSpecularColor)
-			.def("setSpecularColor", &ofMaterial::setSpecularColor)
-			.property("specularColor", &ofMaterial::getSpecularColor, &ofMaterial::setSpecularColor)
-			
-			.def("getEmissiveColor", &ofMaterial::getEmissiveColor)
-			.def("setEmissiveColor", &ofMaterial::setEmissiveColor)
-			.property("emissiveColor", &ofMaterial::getEmissiveColor, &ofMaterial::setEmissiveColor)
-			
+            .def("setColors", (void(ofMaterial::*)(ofFloatColor,ofFloatColor,ofFloatColor,ofFloatColor)) &ofMaterial::setColors)
+            .def("setDiffuseColor", (void(ofMaterial::*)(ofFloatColor)) &ofMaterial::setDiffuseColor)
+            .def("setAmbientColor", (void(ofMaterial::*)(ofFloatColor)) &ofMaterial::setAmbientColor)
+            .def("setSpecularColor", (void(ofMaterial::*)(ofFloatColor)) &ofMaterial::setSpecularColor)
+            .def("setEmissiveColor", (void(ofMaterial::*)(ofFloatColor)) &ofMaterial::setEmissiveColor)
+            .def("getDiffuseColor", (ofFloatColor(ofMaterial::*)(void)) &ofMaterial::getDiffuseColor)
+            .def("getAmbientColor", (ofFloatColor(ofMaterial::*)(void)) &ofMaterial::getAmbientColor)
+            .def("getSpecularColor", (ofFloatColor(ofMaterial::*)(void)) &ofMaterial::getSpecularColor)
+            .def("getEmissiveColor", (ofFloatColor(ofMaterial::*)(void)) &ofMaterial::getEmissiveColor)
 			.def("getShininess", &ofMaterial::getShininess)
 			.def("setShininess", &ofMaterial::setShininess)
 			.property("shininess", &ofMaterial::getShininess, &ofMaterial::setShininess)
-			
 			.def("beginMaterial", &ofMaterial::begin)
 			.def("endMaterial", &ofMaterial::end),
+    
 			
 		///////////////////////////////
 		/// \section ofShader.h

--- a/src/bindings/Types.cpp
+++ b/src/bindings/Types.cpp
@@ -144,6 +144,43 @@ luabind::scope registerTypes() {
 		def("colorFromHex", &colorFromHex1),
 		def("colorFromHex", &ofColor::fromHex),
 			
+    
+        /// \section ofFloatColor
+        
+        class_<ofFloatColor>("FloatColor")
+            .def(constructor<>())
+            .def(constructor<float,float,float,float>())
+            .def(constructor<ofFloatColor const&>())
+            .def(constructor<ofFloatColor const&,float>())
+            .def(constructor<float,float>())
+            .def("getHex", (int(ofFloatColor::*)(void)) &ofFloatColor::getHex)
+            .def("clamp", (ofFloatColor(ofFloatColor::*)(void)) &ofFloatColor::clamp)
+            .def("invert", (ofFloatColor(ofFloatColor::*)(void)) &ofFloatColor::invert)
+            .def("normalize", (ofFloatColor(ofFloatColor::*)(void)) &ofFloatColor::normalize)
+            .def("getClamped", (ofFloatColor(ofFloatColor::*)(void)) &ofFloatColor::getClamped)
+            .def("getInverted", (ofFloatColor(ofFloatColor::*)(void)) &ofFloatColor::getInverted)
+            .def("getNormalized", (ofFloatColor(ofFloatColor::*)(void)) &ofFloatColor::getNormalized)
+            .def("getHue", (float(ofFloatColor::*)(void)) &ofFloatColor::getHue)
+            .def("getSaturation", (float(ofFloatColor::*)(void)) &ofFloatColor::getSaturation)
+            .def("getBrightness", (float(ofFloatColor::*)(void)) &ofFloatColor::getBrightness)
+            .def("getLightness", (float(ofFloatColor::*)(void)) &ofFloatColor::getLightness)
+            .def("setHue", (void(ofFloatColor::*)(float)) &ofFloatColor::setHue)
+            .def("setSaturation", (void(ofFloatColor::*)(float)) &ofFloatColor::setSaturation)
+            .def("setBrightness", (void(ofFloatColor::*)(float)) &ofFloatColor::setBrightness)
+            .def("setHsb", (void(ofFloatColor::*)(float,float,float,float)) &ofFloatColor::setHsb)
+            .def("setHsb", (void(ofFloatColor::*)(float,float,float)) &ofFloatColor::setHsb)
+            .def("set", (void(ofFloatColor::*)(float,float,float,float)) &ofFloatColor::set)
+            .def("set", (void(ofFloatColor::*)(float,float)) &ofFloatColor::set)
+            .def("set", (void(ofFloatColor::*)(ofFloatColor const&)) &ofFloatColor::set)
+            .def("setHex", (void(ofFloatColor::*)(int,float)) &ofFloatColor::setHex)
+            .def("lerp", (ofFloatColor(ofFloatColor::*)(const ofFloatColor&, float)) &ofFloatColor::lerp)
+            .def("getLerped", (ofFloatColor(ofFloatColor::*)(const ofFloatColor&, float)) &ofFloatColor::getLerped)
+            .def("getHsb", (void(ofFloatColor::*)(float&,float&,float&)) &ofFloatColor::getHsb)
+            .def_readonly("r", &ofFloatColor::r)
+            .def_readonly("g", &ofFloatColor::g)
+            .def_readonly("b", &ofFloatColor::b)
+            .def_readonly("a", &ofFloatColor::a),
+    
 		///////////////////////////////
 		/// \section ofRectangle.h
 		


### PR DESCRIPTION
I left the current ofLight color setting functions as to avoid breaking existing projects. Though, I would recommend maybe removing the custom setters in favor of using ofFloatColor. I can do that if necessary.

Also, I can't take much credit for these changes as I'm bringing most of this over from the https://github.com/d3cod3/GAmuza project. It's nice that @d3cod3 did all that work, but I feel it should live in the ofxLua project. If accepted, I will most likely continue to bring over items and add things as I build my projects.
