### PR TITLE
addon_config.mk fixed for Linux

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -29,7 +29,7 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES += src libs/lua libs/lua/lua libs/luabind
+	ADDON_INCLUDES += src src/bindings libs/lua libs/lua/lua libs/luabind
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon


### PR DESCRIPTION
I had to add "src/bindings" in addon_config.mk includes in order to compile in Linux using Makefiles.
