### PR TITLE
Now compiles properly on Raspberry Pi

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -93,14 +93,16 @@ linuxarmv6l:
 	ADDON_PKG_CONFIG_LIBRARIES = luajit
 	ADDON_SOURCES_EXCLUDE += src/bindings/desktop/% src/bindings/ios/%
 	ADDON_INCLUDES_EXCLUDE += src/bindings/desktop/% src/bindings/ios/%
-	ADDON_LIBS_EXCLUDE += libs
+	ADDON_SOURCES_EXCLUDE += libs/%
+	ADDON_INCLUDES_EXCLUDE += libs/%
 	
 linuxarmv7l:
 	ADDON_CFLAGS += -DLUA_USE_LINUX
 	ADDON_PKG_CONFIG_LIBRARIES = luajit
 	ADDON_SOURCES_EXCLUDE += src/bindings/desktop/% src/bindings/ios/%
 	ADDON_INCLUDES_EXCLUDE += src/bindings/desktop/% src/bindings/ios/%
-	ADDON_LIBS_EXCLUDE += libs
+	ADDON_SOURCES_EXCLUDE += libs/%
+	ADDON_INCLUDES_EXCLUDE += libs/%
 
 android/armeabi:
 	# not tested, probably works :)


### PR DESCRIPTION
Setting ADDON_LIBS_EXCLUDE doesn't seem to exclude the Lua source code.
Instead, use ADDON_SOURCES_EXCLUDE and ADDON_INCLUDES_EXCLUDE
to stop the OF makefile system from compiling the Lua source code
into the binary.