### PR TITLE
chdir include

### DIFF
--- a/src/ofxLua.cpp
+++ b/src/ofxLua.cpp
@@ -9,7 +9,7 @@
  *
  * This project uses the following library:
  *
- * Lua, Copyright (c) 1994â2011 Lua.org, PUC-Rio using the MIT License.
+ * Lua, Copyright (c) 1994Ã¢2011 Lua.org, PUC-Rio using the MIT License.
  * See the file "COPYRIGHT" in src/lua.
  * See http://www.lua.org/docs.html for documentation
  *
@@ -24,6 +24,7 @@
 	#include <direct.h>
 	#define CHDIR _chdir
 #else
+	#include <unistd.h>
 	#define CHDIR chdir
 #endif
 #include <errno.h>


### PR DESCRIPTION
This include:
`#include <unistd.h>`
is needed for chdir (at least with Emscripten).